### PR TITLE
fix: catalog_product creating invalid url for paginated requests

### DIFF
--- a/wiopy/AsyncWIO.py
+++ b/wiopy/AsyncWIO.py
@@ -158,7 +158,7 @@ class AsyncWalmartIO:
         https://www.walmart.io/docs/affiliate/catalog-product
         """
         if "nextPage" in kwargs:
-            url = "https://developer.api.walmart" + kwargs.pop("nextPage")
+            url = "https://developer.api.walmart.com" + kwargs.pop("nextPage")
         else:
             url = self.ENDPOINT + "/affil/product/v2/paginated/items"
 

--- a/wiopy/WalmartIO.py
+++ b/wiopy/WalmartIO.py
@@ -158,7 +158,7 @@ class WalmartIO:
         https://www.walmart.io/docs/affiliate/catalog-product
         """
         if "nextPage" in kwargs:
-            url = "https://developer.api.walmart" + kwargs.pop("nextPage")
+            url = "https://developer.api.walmart.com" + kwargs.pop("nextPage")
         else:
             url = self.ENDPOINT + "/affil/product/v2/paginated/items"
 


### PR DESCRIPTION
Passing `nextPage` kwarg to `catalog_product` method results in request to invalid url