### PR TITLE
fix: override typing import on older python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "WIOpy"
-version = "1.2.1"
+version = "1.2.2"
 description = "A Python wrapper for the Walmart IO API"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -9,7 +9,8 @@ requires-python = ">=3.9"
 dependencies = [
     "requests",
     "pycryptodome",
-    "aiohttp"
+    "aiohttp",
+    "typing-extensions>=4.5.0; python_version < '3.12'",
 ]
 keywords = [
     "API",

--- a/uv.lock
+++ b/uv.lock
@@ -701,12 +701,13 @@ wheels = [
 
 [[package]]
 name = "wiopy"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "pycryptodome" },
     { name = "requests" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -720,6 +721,7 @@ requires-dist = [
     { name = "aiohttp" },
     { name = "pycryptodome" },
     { name = "requests" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.5.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/wiopy/WalmartResponse.py
+++ b/wiopy/WalmartResponse.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import sys
 from html import unescape
-from typing import Any, Final, cast, override
+from typing import Any, Final, cast
+
+# pyright: basic
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+# pyright: strict
 
 __all__ = (
     "OverallRating",


### PR DESCRIPTION
```py
from typing import override
```

The above is not valid in python `<3.12`. As such, I have replaced it with a compatible option. Allowing us to correctly be able to import older python versions.  